### PR TITLE
use babel-import-util

### DIFF
--- a/packages/model/index.js
+++ b/packages/model/index.js
@@ -42,6 +42,7 @@ module.exports = Object.assign({}, addonBaseConfig, {
       'ember-inflector',
       'ember',
       'rsvp',
+      '@embroider/macros/runtime',
     ];
   },
 });

--- a/packages/private-build-infra/package.json
+++ b/packages/private-build-infra/package.json
@@ -23,6 +23,7 @@
     "@ember/edition-utils": "^1.2.0",
     "babel-plugin-debug-macros": "^0.3.4",
     "babel-plugin-filter-imports": "^4.0.0",
+    "babel-import-util": "^1.2.2",
     "babel6-plugin-strip-class-callcheck": "^6.0.0",
     "broccoli-debug": "^0.6.5",
     "broccoli-file-creator": "^2.1.1",

--- a/packages/private-build-infra/src/debug-macros.js
+++ b/packages/private-build-infra/src/debug-macros.js
@@ -34,6 +34,13 @@ module.exports = function debugMacros(app, isProd, config) {
       '@ember-data/canary-features-stripping',
     ],
     [
+      ConvertExistenceChecksToMacros,
+      {
+        source: '@ember-data/private-build-infra',
+        flags: MACRO_PACKAGE_FLAGS,
+      },
+    ],
+    [
       debugMacrosPath,
       {
         flags: [
@@ -58,13 +65,6 @@ module.exports = function debugMacros(app, isProd, config) {
       '@ember-data/debugging',
     ],
     [
-      ConvertExistenceChecksToMacros,
-      {
-        source: '@ember-data/private-build-infra',
-        flags: MACRO_PACKAGE_FLAGS,
-      },
-    ],
-    [
       debugMacrosPath,
       {
         flags: [
@@ -77,5 +77,6 @@ module.exports = function debugMacros(app, isProd, config) {
       '@ember-data/optional-packages-stripping',
     ],
   ];
+
   return plugins;
 };

--- a/packages/private-build-infra/src/stripped-build-plugins.js
+++ b/packages/private-build-infra/src/stripped-build-plugins.js
@@ -22,5 +22,6 @@ module.exports = function (environment, app, config) {
   }
 
   plugins.push(...DebugMacros);
+
   return { plugins, postTransformPlugins };
 };

--- a/packages/private-build-infra/src/transforms/babel-plugin-convert-existence-checks-to-macros/index.js
+++ b/packages/private-build-infra/src/transforms/babel-plugin-convert-existence-checks-to-macros/index.js
@@ -1,43 +1,4 @@
-function setupState(t, path, state) {
-  let allAddedImports = {};
-  let importedModules = {};
-  state.ensureImport = (exportName, moduleName) => {
-    let addedImports = (allAddedImports[moduleName] = allAddedImports[moduleName] || {});
-    if (addedImports[exportName]) return addedImports[exportName];
-
-    let importDeclarations = path.get('body').filter((n) => n.type === 'ImportDeclaration');
-
-    let preexistingImportDeclaration = importDeclarations.find((n) => n.get('source').get('value').node === moduleName);
-
-    if (preexistingImportDeclaration) {
-      let importSpecifier = preexistingImportDeclaration.get('specifiers').find(({ node }) => {
-        return exportName === 'default' ? t.isImportDefaultSpecifier(node) : node.imported.name === exportName;
-      });
-      if (importSpecifier) {
-        addedImports[exportName] = importSpecifier.node.local;
-      } else {
-        const newImportSpecifier = t.importSpecifier(t.identifier(exportName), t.identifier(exportName));
-        preexistingImportDeclaration.node.specifiers.push(newImportSpecifier);
-        addedImports[exportName] = newImportSpecifier;
-      }
-    }
-
-    if (!addedImports[exportName]) {
-      addedImports[exportName] = exportName;
-      let newImport = t.importDeclaration(
-        [t.importSpecifier(t.identifier(exportName), t.identifier(exportName))],
-        t.stringLiteral(moduleName)
-      );
-      path.unshiftContainer('body', newImport);
-    }
-
-    if (!importedModules[moduleName]) {
-      importedModules[moduleName] = [];
-    }
-    importedModules[moduleName].push(addedImports[exportName]);
-    return addedImports[exportName];
-  };
-}
+const { ImportUtil } = require('babel-import-util');
 
 module.exports = function (babel) {
   const { types: t } = babel;
@@ -58,15 +19,15 @@ module.exports = function (babel) {
               let binding = specifier.scope.getBinding(localBindingName);
               binding.referencePaths.forEach((p) => {
                 p.replaceWith(
-                  t.callExpression(t.identifier('macroCondition'), [
-                    t.callExpression(t.identifier('moduleExists'), [t.stringLiteral(replacements[name])]),
+                  // t.callExpression(state.importer.import(p, '@embroider/macros', 'macroCondition'), [
+                  t.callExpression(state.importer.import(p, '@embroider/macros', 'moduleExists'), [
+                    t.stringLiteral(replacements[name]),
                   ])
+                  // ])
                 );
               });
               specifier.scope.removeOwnBinding(localBindingName);
               specifier.remove();
-              state.ensureImport('macroCondition', '@embroider/macros');
-              state.ensureImport('moduleExists', '@embroider/macros');
             }
           });
         }
@@ -76,7 +37,7 @@ module.exports = function (babel) {
       },
 
       Program(path, state) {
-        setupState(t, path, state);
+        state.importer = new ImportUtil(t, path);
       },
     },
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3729,7 +3729,7 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-import-util@^1.1.0, babel-import-util@^1.2.0:
+babel-import-util@^1.1.0, babel-import-util@^1.2.0, babel-import-util@^1.2.2:
   version "1.2.2"
   resolved "https://registry.npmjs.org/babel-import-util/-/babel-import-util-1.2.2.tgz#1027560e143a4a68b1758e71d4fadc661614e495"
   integrity sha512-8HgkHWt5WawRFukO30TuaL9EiDUOdvyKtDwLma4uBNeUSDbOO0/hiPfavrOWxSS6J6TKXfukWHZ3wiqZhJ8ONQ==
@@ -7261,7 +7261,8 @@ eslint-module-utils@^2.7.3:
     find-up "^2.1.0"
 
 "eslint-plugin-ember-data@link:./packages/unpublished-eslint-rules":
-  version "4.8.0-alpha.6"
+  version "0.0.0"
+  uid ""
 
 eslint-plugin-ember@^11.0.6:
   version "11.0.6"


### PR DESCRIPTION
The fiddly details of manipulating import statements without clobbering any existing scope and while maintaining babel's bindings analysis are difficult to get right on the first try, which is why i made babel-import-util. Using it is enough to get things composing correctly with the other babel plugin provided by `@embroider/macros`.

I commented out the usage of `macroCondition`, not because that isn't a good idea, but because the existing usage of the `HAS_*_PACKAGE` flags has ambiguous cases that cannot be statically analyzed, and `macroCondition` was created to disallow those ambiguous cases.

The point of `macroCondition` is to *guarantee* that a conditional will be statically analyzable. It exists to give you a build error if the conditional cannot be statically analyzed.

The commented out code would work correctly for cases like:

```js
// original
if (HAS_RECORD_DATA_PACKAGE) {
}

// transformed
if (macroCondition(moduleExists('@ember-data/record-data')) {
}
```

But it would not work for:

```js
// original
if (!HAS_RECORD_DATA_PACKAGE) {
}

// transformed: build error from macroCondition because it is required to be the topmost thing inside the predicate
if (!macroCondition(moduleExists('@ember-data/record-data'))) {
}

// corrected version would be this instead
if (macroCondition(!moduleExists('@ember-data/record-data'))) {
}
```

Changing the babel plugin to handle the above case is not very difficult (the code would crawl upward looking for the nearest `IfStatement` to insert the `macroCondition` wrapper into). However, there are a few other worse cases that are actually not analyzable:

https://github.com/emberjs/data/blob/94cf39f3b0740e91b389021bad3d7f9ecc57f810/packages/store/addon/-private/legacy-model-support/schema-definition-service.ts#L117

```js
// original
if (!factory && HAS_MODEL_PACKAGE) {
}

// even the ideal transformed version is a build error
if (macroCondition(!factory && moduleExists('@ember-data/record-data'))) {
}
```

because `factory` is not knowable at build time, so this branch cannot be reliably eliminated.

For this reason, you could decide *not* to use macroCondition and continue to rely on the softer form of optimization provided by terser, etc. 

